### PR TITLE
Remove unnecessary `unsafe` in skipdb-core

### DIFF
--- a/async-skipdb/src/optimistic.rs
+++ b/async-skipdb/src/optimistic.rs
@@ -1,3 +1,4 @@
+use skipdb_core::types::Values;
 use std::{collections::hash_map::RandomState, hash::Hash};
 
 use super::*;
@@ -134,6 +135,7 @@ impl<K, V, SP, S> OptimisticDb<K, V, SP, S>
 where
   K: Ord + Eq + Hash + Send + 'static,
   V: Send + 'static,
+  Values<V>: Send,
   SP: AsyncSpawner,
 {
   /// Compact the database.

--- a/async-skipdb/src/serializable.rs
+++ b/async-skipdb/src/serializable.rs
@@ -1,5 +1,6 @@
 use async_txn::{AsyncSpawner, BTreeCm};
 pub use cheap_clone::CheapClone;
+use skipdb_core::types::Values;
 
 use super::*;
 
@@ -136,6 +137,7 @@ impl<K, V, S> SerializableDb<K, V, S>
 where
   K: CheapClone + Ord + Send + 'static,
   V: Send + 'static,
+  Values<V>: Send,
   S: AsyncSpawner,
 {
   /// Compact the database.

--- a/skipdb-core/src/lib.rs
+++ b/skipdb-core/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(warnings)]
+#![forbid(unsafe_code)]
 #![allow(clippy::type_complexity)]
 
 extern crate alloc;
@@ -182,6 +183,7 @@ impl<K, V> SkipCore<K, V>
 where
   K: Ord + Send + 'static,
   V: Send + 'static,
+  Values<V>: Send,
 {
   pub fn compact(&self, new_discard_version: u64) {
     match self

--- a/skipdb-core/src/types.rs
+++ b/skipdb-core/src/types.rs
@@ -18,8 +18,6 @@ pub struct Values<V> {
   values: SkipMap<u64, Option<V>>,
 }
 
-unsafe impl<V: Send> Send for Values<V> {}
-
 impl<V> Values<V> {
   pub(crate) fn new() -> Self {
     Self {
@@ -170,5 +168,18 @@ where
   #[inline]
   fn eq(&self, other: &&V) -> bool {
     core::ops::Deref::deref(self).eq(other)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_values_send() {
+    fn takes_send<T: Send>(_t: T) {}
+
+    let values = Values::<()>::new();
+    takes_send(values);
   }
 }

--- a/skipdb/src/optimistic.rs
+++ b/skipdb/src/optimistic.rs
@@ -1,4 +1,5 @@
 use super::*;
+use skipdb_core::types::Values;
 use std::{collections::hash_map::RandomState, hash::Hash};
 
 mod write;
@@ -124,6 +125,7 @@ impl<K, V, S> OptimisticDb<K, V, S>
 where
   K: Ord + Eq + Hash + Send + 'static,
   V: Send + 'static,
+  Values<V>: Send,
   S: BuildHasher + Clone,
 {
   /// Compact the database.

--- a/skipdb/src/serializable.rs
+++ b/skipdb/src/serializable.rs
@@ -1,4 +1,5 @@
 pub use cheap_clone::CheapClone;
+use skipdb_core::types::Values;
 use txn::BTreeCm;
 
 use super::*;
@@ -126,6 +127,7 @@ impl<K, V> SerializableDb<K, V>
 where
   K: CheapClone + Ord + Send + 'static,
   V: Send + 'static,
+  Values<V>: Send,
 {
   /// Compact the database.
   #[inline]


### PR DESCRIPTION
- Adds a test that proves `Values: Send` without the unsafe trait impl.
- Adds an extra constraint to functions that require `Values<V>: Send`.
- Adds `#![forbid(unsafe_code)]` to skipdb-core.